### PR TITLE
Fix support for composer 2.2.1+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,5 +40,10 @@
 			"ModernTimeline\\": "src/",
 			"ModernTimeline\\Tests\\": "tests/"
 		}
+	},
+	"config": {
+		"allow-plugins": {
+			"composer/installers": true
+		}
 	}
 }


### PR DESCRIPTION
Composer 2.2.1+ requires plugins to be allowed