### PR TITLE
Add CS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,3 +117,127 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
         if: matrix.mw == 'master'
+
+  PHPStan:
+    name: "PHPStan: MW ${{ matrix.mw }}, PHP ${{ matrix.php }}"
+
+    strategy:
+      matrix:
+        include:
+          - mw: 'REL1_43'
+            php: '8.3'
+            db: 'sqlite'
+            smw: 'dev-master'
+
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: mediawiki
+
+    steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: mbstring
+          tools: composer, cs2pr
+
+      - name: Cache MediaWiki
+        id: cache-mediawiki
+        uses: actions/cache@v4
+        with:
+          path: |
+            mediawiki
+            mediawiki/extensions/
+            mediawiki/vendor/
+          key: mw_${{ matrix.mw }}-php${{ matrix.php }}_v1
+
+      - name: Cache Composer cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache
+          key: composer_static_analysis
+
+      - uses: actions/checkout@v4
+        with:
+          path: EarlyCopy
+
+      - name: Install MediaWiki
+        if: steps.cache-mediawiki.outputs.cache-hit != 'true'
+        working-directory: ~
+        run: bash EarlyCopy/.github/workflows/installMediaWiki.sh ${{ matrix.mw }} ${{ matrix.db }} ${{ matrix.smw }} ModernTimeline
+
+      - uses: actions/checkout@v4
+        with:
+          path: mediawiki/extensions/ModernTimeline
+
+      - name: Composer allow-plugins
+        run: composer config --no-plugins allow-plugins.composer/installers true
+
+      - run: composer update
+
+      - name: Composer install
+        run: cd extensions/ModernTimeline && composer install --no-progress --no-interaction --prefer-dist --optimize-autoloader
+
+      - name: PHPStan
+        run: cd extensions/ModernTimeline && php vendor/bin/phpstan analyse --error-format=checkstyle --no-progress | cs2pr
+
+  phpcs:
+    name: "Code style: MW ${{ matrix.mw }}, PHP ${{ matrix.php }}"
+
+    strategy:
+      matrix:
+        include:
+          - mw: 'REL1_43'
+            php: '8.3'
+            db: 'sqlite'
+            smw: 'dev-master'
+
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: mediawiki/extensions/ModernTimeline
+
+    steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: mbstring, intl, php-ast
+          tools: composer
+
+      - name: Cache MediaWiki
+        id: cache-mediawiki
+        uses: actions/cache@v4
+        with:
+          path: |
+            mediawiki
+            !mediawiki/extensions/
+            !mediawiki/vendor/
+          key: mw_static_analysis
+
+      - name: Cache Composer cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache
+          key: composer_static_analysis
+
+      - uses: actions/checkout@v4
+        with:
+          path: EarlyCopy
+
+      - name: Install MediaWiki
+        if: steps.cache-mediawiki.outputs.cache-hit != 'true'
+        working-directory: ~
+        run: bash EarlyCopy/.github/workflows/installMediaWiki.sh ${{ matrix.mw }} ${{ matrix.db }} ${{ matrix.smw }} ModernTimeline
+
+      - uses: actions/checkout@v4
+        with:
+          path: mediawiki/extensions/ModernTimeline
+
+      - name: Composer install
+        run: composer install --no-progress --no-interaction --prefer-dist --optimize-autoloader
+
+      - run: vendor/bin/phpcs -p -s

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+vendor/
 .phpunit.result.cache
+composer.lock

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+.PHONY: ci test cs phpunit phpcs stan
+
+ci: test cs
+test: phpunit
+cs: phpcs stan
+
+phpunit:
+ifdef filter
+	php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist --filter $(filter)
+else
+	php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist
+endif
+
+perf:
+	php ../../tests/phpunit/phpunit.php -c phpunit.xml.dist --group Performance
+
+phpcs:
+	vendor/bin/phpcs -p -s --standard=$(shell pwd)/phpcs.xml
+
+stan:
+	vendor/bin/phpstan analyse --configuration=phpstan.neon --memory-limit=2G
+
+stan-baseline:
+	vendor/bin/phpstan analyse --configuration=phpstan.neon --memory-limit=2G --generate-baseline

--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ have a look at the contribution guideline.
 
 Under development.
 
+* Raised minimum PHP version to 8.0
+* Raised minimum MediaWiki version to 1.39
 * Upgraded to TimelineJS3 3.9.6
 * Translation updates from https://translatewiki.net
 

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 		"source": "https://github.com/ProfessionalWiki/ModernTimeline"
 	},
 	"require": {
-		"php": ">=7.1",
+		"php": ">=8.0",
 		"composer/installers": "^2|^1.0.1",
 		"param-processor/param-processor": "~1.10"
 	},

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,10 @@
 		"composer/installers": "^2|^1.0.1",
 		"param-processor/param-processor": "~1.10"
 	},
+	"require-dev": {
+		"phpstan/phpstan": "^2.0.1",
+		"mediawiki/mediawiki-codesniffer": "^46.0.0"
+	},
 	"autoload": {
 		"psr-4": {
 			"ModernTimeline\\": "src/",
@@ -43,7 +47,8 @@
 	},
 	"config": {
 		"allow-plugins": {
-			"composer/installers": true
+			"composer/installers": true,
+			"dealerdirect/phpcodesniffer-composer-installer": true
 		}
 	}
 }

--- a/extension.json
+++ b/extension.json
@@ -19,9 +19,9 @@
 	"type": "semantic",
 
 	"requires": {
-		"MediaWiki": ">= 1.31.0",
+		"MediaWiki": ">= 1.39.0",
 		"extensions": {
-			"SemanticMediaWiki": ">= 3.0.0"
+			"SemanticMediaWiki": ">= 4.0.0"
 		}
 	},
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -24,6 +24,7 @@
 		<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EndLine" />
 		<exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace" />
 		<exclude name="Universal.WhiteSpace.CommaSpacing.SpaceBeforeInFunctionCall" />
+		<exclude name="Generic.Metrics.NestingLevel.TooHigh" />
 	</rule>
 
 	<rule ref="Generic.Formatting.NoSpaceAfterCast" />

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<ruleset>
+	<file>src/</file>
+	<file>tests/</file>
+
+	<arg name="extensions" value="php"/>
+
+	<rule ref="./vendor/mediawiki/mediawiki-codesniffer/MediaWiki">
+		<exclude name="Generic.Files.LineLength.TooLong" />
+		<exclude name="MediaWiki.Commenting.FunctionComment" />
+		<exclude name="MediaWiki.Commenting.PropertyDocumentation" />
+		<exclude name="MediaWiki.Commenting.FunctionAnnotations.UnrecognizedAnnotation" />
+		<exclude name="MediaWiki.Commenting.MissingCovers.MissingCovers" />
+		<exclude name="MediaWiki.ControlStructures.IfElseStructure.SpaceBeforeElse" />
+		<exclude name="MediaWiki.WhiteSpace.SpaceBeforeSingleLineComment" />
+		<exclude name="MediaWiki.WhiteSpace.DisallowEmptyLineFunctions.NoEmptyLine" />
+		<exclude name="MediaWiki.WhiteSpace.SpaceAfterClosure.NoWhitespaceAfterClosure" />
+		<exclude name="MediaWiki.WhiteSpace.SameLineCatch.CatchNotOnSameLine" />
+		<exclude name="MediaWiki.WhiteSpace.SpaceAfterClosure.NoWhitespaceAfterArrow" />
+		<exclude name="MediaWiki.Classes.UnusedUseStatement.UnusedUse" />
+		<exclude name="MediaWiki.Classes.UnsortedUseStatements.UnsortedUse" />
+		<exclude name="MediaWiki.Usage.StaticClosure.StaticClosure" />
+		<exclude name="MediaWiki.PHPUnit.MockBoilerplate.ConstraintEqualTo" />
+		<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EndLine" />
+		<exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace" />
+		<exclude name="Universal.WhiteSpace.CommaSpacing.SpaceBeforeInFunctionCall" />
+	</rule>
+
+	<rule ref="Generic.Formatting.NoSpaceAfterCast" />
+	<rule ref="Generic.Metrics.CyclomaticComplexity" />
+	<rule ref="Generic.Metrics.NestingLevel" />
+	<rule ref="Squiz.Operators.ValidLogicalOperators" />
+</ruleset>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,49 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Call to an undefined method SMWDataItem\:\:getTitle\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/EventExtractor.php
+
+		-
+			message: '#^Cannot call method getURL\(\) on File\|false\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/EventExtractor.php
+
+		-
+			message: '#^Parameter \#1 \$title of method ModernTimeline\\JsonBuilder\:\:newHeadline\(\) expects MediaWiki\\Title\\Title, MediaWiki\\Title\\Title\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/JsonBuilder.php
+
+		-
+			message: '#^Method ModernTimeline\\ModernTimelinePrinter\:\:getQueryMode\(\) has parameter \$context with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/ModernTimelinePrinter.php
+
+		-
+			message: '#^Cannot access offset ''moderntimeline'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/ModernTimelineSetup.php
+
+		-
+			message: '#^Class ModernTimeline\\ResultFacade\\PropertyValueCollections implements generic interface IteratorAggregate but does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: src/ResultFacade/PropertyValueCollections.php
+
+		-
+			message: '#^Cannot call method getFullText\(\) on MediaWiki\\Title\\Title\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/SlidePresenter/TemplateSlidePresenter.php
+
+		-
+			message: '#^Method ModernTimeline\\TimelinePresenter\:\:createJsonString\(\) should return string but returns string\|false\.$#'
+			identifier: return.type
+			count: 1
+			path: src/TimelinePresenter.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,8 +1,14 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Call to an undefined method SMWDataItem\:\:getTitle\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Cannot call method getDataItems\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/EventExtractor.php
+
+		-
+			message: '#^Cannot call method getPrintRequest\(\) on mixed\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/EventExtractor.php
 
@@ -113,6 +119,18 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/ResultFacade/SubjectCollection.php
+
+		-
+			message: '#^Cannot call method getDataItems\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/SlidePresenter/SimpleSlidePresenter.php
+
+		-
+			message: '#^Cannot call method getPrintRequest\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 2
+			path: src/SlidePresenter/SimpleSlidePresenter.php
 
 		-
 			message: '#^Method ModernTimeline\\SlidePresenter\\SimpleSlidePresenter\:\:__construct\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13,14 +13,56 @@ parameters:
 			path: src/EventExtractor.php
 
 		-
+			message: '#^Method ModernTimeline\\EventExtractor\:\:__construct\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/EventExtractor.php
+
+		-
+			message: '#^Method ModernTimeline\\EventExtractor\:\:getDates\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/EventExtractor.php
+
+		-
+			message: '#^Method ModernTimeline\\JsonBuilder\:\:buildEvent\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/JsonBuilder.php
+
+		-
+			message: '#^Method ModernTimeline\\JsonBuilder\:\:eventsToTimelineJson\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/JsonBuilder.php
+
+		-
+			message: '#^Method ModernTimeline\\JsonBuilder\:\:timeToJson\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/JsonBuilder.php
+
+		-
 			message: '#^Parameter \#1 \$title of method ModernTimeline\\JsonBuilder\:\:newHeadline\(\) expects MediaWiki\\Title\\Title, MediaWiki\\Title\\Title\|null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/JsonBuilder.php
 
 		-
+			message: '#^Method ModernTimeline\\ModernTimelinePrinter\:\:getParamDefinitions\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/ModernTimelinePrinter.php
+
+		-
 			message: '#^Method ModernTimeline\\ModernTimelinePrinter\:\:getQueryMode\(\) has parameter \$context with no type specified\.$#'
 			identifier: missingType.parameter
+			count: 1
+			path: src/ModernTimelinePrinter.php
+
+		-
+			message: '#^Method ModernTimeline\\ModernTimelinePrinter\:\:newProcessingResultFromParams\(\) has parameter \$params with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/ModernTimelinePrinter.php
 
@@ -37,10 +79,94 @@ parameters:
 			path: src/ResultFacade/PropertyValueCollections.php
 
 		-
+			message: '#^Method ModernTimeline\\ResultFacade\\ResultFormat\:\:__construct\(\) has parameter \$parameterDefinitions with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/ResultFacade/ResultFormat.php
+
+		-
+			message: '#^Method ModernTimeline\\ResultFacade\\ResultFormat\:\:getParameterDefinitions\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/ResultFacade/ResultFormat.php
+
+		-
+			message: '#^Method ModernTimeline\\ResultFacade\\ResultFormatRegistrator\:\:andParameterDefinitions\(\) has parameter \$parameterDefinitions with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/ResultFacade/ResultFormatRegistrator.php
+
+		-
+			message: '#^Property ModernTimeline\\ResultFacade\\ResultFormatRegistrator\:\:\$parameterDefinitions type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/ResultFacade/ResultFormatRegistrator.php
+
+		-
+			message: '#^Method ModernTimeline\\ResultFacade\\SimpleQueryResult\:\:getParameters\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/ResultFacade/SimpleQueryResult.php
+
+		-
+			message: '#^Property ModernTimeline\\ResultFacade\\SubjectCollection\:\:\$pages type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/ResultFacade/SubjectCollection.php
+
+		-
+			message: '#^Method ModernTimeline\\SlidePresenter\\SimpleSlidePresenter\:\:__construct\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/SlidePresenter/SimpleSlidePresenter.php
+
+		-
+			message: '#^Method ModernTimeline\\SlidePresenter\\SimpleSlidePresenter\:\:getDisplayValues\(\) return type has no value type specified in iterable type Traversable\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/SlidePresenter/SimpleSlidePresenter.php
+
+		-
 			message: '#^Cannot call method getFullText\(\) on MediaWiki\\Title\\Title\|null\.$#'
 			identifier: method.nonObject
 			count: 1
 			path: src/SlidePresenter/TemplateSlidePresenter.php
+
+		-
+			message: '#^Method ModernTimeline\\SlidePresenter\\TemplateSlidePresenter\:\:getTemplateSegments\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/SlidePresenter/TemplateSlidePresenter.php
+
+		-
+			message: '#^Method ModernTimeline\\TimelineOptions\:\:getStartAtSlide\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/TimelineOptions.php
+
+		-
+			message: '#^Method ModernTimeline\\TimelineOptions\:\:getTimelineParameterDefinitions\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/TimelineOptions.php
+
+		-
+			message: '#^Method ModernTimeline\\TimelineOptions\:\:processedParamsToJson\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/TimelineOptions.php
+
+		-
+			message: '#^Method ModernTimeline\\TimelineOptions\:\:processedParamsToJson\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/TimelineOptions.php
+
+		-
+			message: '#^Method ModernTimeline\\TimelinePresenter\:\:createDiv\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/TimelinePresenter.php
 
 		-
 			message: '#^Method ModernTimeline\\TimelinePresenter\:\:createJsonString\(\) should return string but returns string\|false\.$#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,14 @@
+includes:
+	- phpstan-baseline.neon
+
+parameters:
+	level: 9
+	paths:
+		- src
+	scanDirectories:
+		- ../../includes
+		- ../../tests/phpunit
+		- ../../vendor
+	bootstrapFiles:
+		- ../../includes/AutoLoader.php
+	reportUnmatchedIgnoredErrors: false

--- a/src/Event.php
+++ b/src/Event.php
@@ -9,15 +9,13 @@ use SMWDITime;
 
 class Event {
 
-	private $subject;
-	private $startDate;
-	private $endDate;
-	private $imageUrl;
+	private string $imageUrl = '';
 
-	public function __construct( Subject $subject, SMWDITime $startDate, ?SMWDITime $endDate ) {
-		$this->subject = $subject;
-		$this->startDate = $startDate;
-		$this->endDate = $endDate;
+	public function __construct(
+		private Subject $subject,
+		private SMWDITime $startDate,
+		private ?SMWDITime $endDate
+	) {
 	}
 
 	public function getSubject(): Subject {
@@ -33,14 +31,14 @@ class Event {
 	}
 
 	public function hasImage(): bool {
-		return $this->imageUrl !== null;
+		return $this->imageUrl !== '';
 	}
 
 	public function getImageUrl(): string {
 		return $this->imageUrl;
 	}
 
-	public function setImageUrl( string $url ) {
+	public function setImageUrl( string $url ): void {
 		$this->imageUrl = $url;
 	}
 

--- a/src/EventExtractor.php
+++ b/src/EventExtractor.php
@@ -77,7 +77,7 @@ class EventExtractor {
 				if ( $startDate === null ) {
 					$startDate = $dataItem;
 				}
-				else if ( $endDate === null ) {
+				elseif ( $endDate === null ) {
 					$endDate = $dataItem;
 					break;
 				}

--- a/src/EventExtractor.php
+++ b/src/EventExtractor.php
@@ -14,10 +14,9 @@ use SMWDITime;
 
 class EventExtractor {
 
-	private $parameters;
-
-	public function __construct( array $parameters ) {
-		$this->parameters = $parameters;
+	public function __construct(
+		private array $parameters
+	) {
 	}
 
 	/**
@@ -50,7 +49,7 @@ class EventExtractor {
 		return $events;
 	}
 
-	private function isImageValue( \SMWDataItem $dataItem ) {
+	private function isImageValue( \SMWDataItem $dataItem ): bool {
 		return $dataItem instanceof DIWikiPage
 			&& $dataItem->getTitle() instanceof \Title
 			&& $dataItem->getTitle()->getNamespace() === NS_FILE
@@ -58,12 +57,7 @@ class EventExtractor {
 	}
 
 	public function getUrlForFileTitle( \Title $existingTitle ): string {
-		if ( method_exists( MediaWikiServices::class, 'getRepoGroup' ) ) {
-			// MediaWiki 1.34+
-			return MediaWikiServices::getInstance()->getRepoGroup()->findFile( $existingTitle )->getURL();
-		} else {
-			return RepoGroup::singleton()->findFile( $existingTitle )->getURL();
-		}
+		return MediaWikiServices::getInstance()->getRepoGroup()->findFile( $existingTitle )->getURL();
 	}
 
 	private function getDates( Subject $subject ): array {
@@ -90,7 +84,7 @@ class EventExtractor {
 	/**
 	 * @return PropertyValueCollection[]
 	 */
-	private function getPropertyValueCollectionsWithDates( Subject $subject ) {
+	private function getPropertyValueCollectionsWithDates( Subject $subject ): array {
 		return array_filter(
 			$subject->getPropertyValueCollections()->toArray(),
 			function( PropertyValueCollection $pvc ) {

--- a/src/JsonBuilder.php
+++ b/src/JsonBuilder.php
@@ -36,7 +36,7 @@ class JsonBuilder {
 		$jsonEvent = [
 			'text' => [
 				'headline' => $this->newHeadline( $event->getSubject()->getWikiPage()->getTitle() ),
-				'text' =>  $this->slidePresenter->getText( $event->getSubject() )
+				'text' => $this->slidePresenter->getText( $event->getSubject() )
 			],
 			'start_date' => $this->timeToJson( $event->getStartDate() ),
 		];

--- a/src/JsonBuilder.php
+++ b/src/JsonBuilder.php
@@ -10,10 +10,9 @@ use SMWDITime;
 
 class JsonBuilder {
 
-	private $slidePresenter;
-
-	public function __construct( SlidePresenter $slidePresenter ) {
-		$this->slidePresenter = $slidePresenter;
+	public function __construct(
+		private SlidePresenter $slidePresenter
+	) {
 	}
 
 	/**

--- a/src/ModernTimelinePrinter.php
+++ b/src/ModernTimelinePrinter.php
@@ -19,10 +19,7 @@ use SMWQuery;
 
 class ModernTimelinePrinter implements ResultPrinter {
 
-	/**
-	 * @var ResultFormat
-	 */
-	private $format;
+	private ResultFormat $format;
 
 	public function __construct() {
 		$registry = new ResultFormatRegistry();
@@ -99,7 +96,7 @@ class ModernTimelinePrinter implements ResultPrinter {
 		return SMWQuery::MODE_INSTANCES;
 	}
 
-	public function setShowErrors( $show ) {
+	public function setShowErrors( $show ): void {
 	}
 
 	public function isExportFormat(): bool {
@@ -118,6 +115,6 @@ class ModernTimelinePrinter implements ResultPrinter {
 		return false;
 	}
 
-	public function setRecursiveTextProcessor( RecursiveTextProcessor $recursiveTextProcessor ) {
+	public function setRecursiveTextProcessor( RecursiveTextProcessor $recursiveTextProcessor ): void {
 	}
 }

--- a/src/ModernTimelineSetup.php
+++ b/src/ModernTimelineSetup.php
@@ -6,13 +6,13 @@ namespace ModernTimeline;
 
 class ModernTimelineSetup {
 
-	public static function onExtensionFunction() {
+	public static function onExtensionFunction(): void {
 		self::doSmwCheck();
 
 		$GLOBALS['smwgResultFormats']['moderntimeline'] = ModernTimelinePrinter::class;
 	}
 
-	private static function doSmwCheck() {
+	private static function doSmwCheck(): void {
 		if ( !defined( 'SMW_VERSION' ) ) {
 
 			if ( PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg' ) {

--- a/src/ResultFacade/PropertyValueCollection.php
+++ b/src/ResultFacade/PropertyValueCollection.php
@@ -9,16 +9,13 @@ use SMWDataItem;
 
 class PropertyValueCollection {
 
-	private $printRequest;
-	private $dataItems;
-
 	/**
-	 * @param PrintRequest $printRequest
 	 * @param SMWDataItem[] $dataItems
 	 */
-	public function __construct( PrintRequest $printRequest, array $dataItems ) {
-		$this->printRequest = $printRequest;
-		$this->dataItems = $dataItems;
+	public function __construct(
+		private PrintRequest $printRequest,
+		private array $dataItems
+	) {
 	}
 
 	public function getPrintRequest(): PrintRequest {

--- a/src/ResultFacade/PropertyValueCollections.php
+++ b/src/ResultFacade/PropertyValueCollections.php
@@ -8,13 +8,12 @@ use Traversable;
 
 class PropertyValueCollections implements \IteratorAggregate {
 
-	private $propertyValueCollections;
-
 	/**
 	 * @param PropertyValueCollection[] $propertyValueCollections
 	 */
-	public function __construct( array $propertyValueCollections ) {
-		$this->propertyValueCollections = $propertyValueCollections;
+	public function __construct(
+		private array $propertyValueCollections
+	) {
 	}
 
 	/**

--- a/src/ResultFacade/ResultFormat.php
+++ b/src/ResultFacade/ResultFormat.php
@@ -6,15 +6,17 @@ namespace ModernTimeline\ResultFacade;
 
 class ResultFormat {
 
-	private $name;
-	private $nameMessageKey;
-	private $parameterDefinitions;
+	/**
+	 * @var callable
+	 */
 	private $constructionFunction;
 
-	public function __construct( string $name, string $nameMessageKey, array $parameterDefinitions, callable $presenterBuilder ) {
-		$this->name = $name;
-		$this->nameMessageKey = $nameMessageKey;
-		$this->parameterDefinitions = $parameterDefinitions;
+	public function __construct(
+		private string $name,
+		private string $nameMessageKey,
+		private array $parameterDefinitions,
+		callable $presenterBuilder
+	) {
 		$this->constructionFunction = $presenterBuilder;
 	}
 

--- a/src/ResultFacade/ResultFormatRegistrator.php
+++ b/src/ResultFacade/ResultFormatRegistrator.php
@@ -6,11 +6,18 @@ namespace ModernTimeline\ResultFacade;
 
 class ResultFormatRegistrator {
 
+	/**
+	 * @var callable
+	 */
 	private $registry;
 
-	private $name;
-	private $nameMessageKey;
-	private $parameterDefinitions;
+	private string $name;
+	private string $nameMessageKey;
+	private array $parameterDefinitions;
+
+	/**
+	 * @var callable
+	 */
 	private $constructionFunction;
 
 	public function __construct( callable $registry ) {
@@ -37,7 +44,7 @@ class ResultFormatRegistrator {
 		return $this;
 	}
 
-	public function register() {
+	public function register(): void {
 		call_user_func( $this->registry, $this->newResultFormat() );
 	}
 

--- a/src/ResultFacade/ResultSimplifier.php
+++ b/src/ResultFacade/ResultSimplifier.php
@@ -42,17 +42,8 @@ class ResultSimplifier {
 		return new Subject( $resultPage, $propertyValueCollections );
 	}
 
-	/**
-	 * Compat with SMW 3.0
-	 * In 3.1+ do: ResultArray::factory( $resultPage, $printRequest, $result )
-	 */
 	private function newResultArray( DIWikiPage $resultPage, PrintRequest $printRequest, QueryResult $result ): ResultArray {
-		return new ResultArray(
-			$resultPage,
-			$printRequest,
-			$result->getStore(),
-			method_exists( $result, 'getFieldItemFinder' ) ? $result->getFieldItemFinder() : null
-		);
+		return ResultArray::factory( $resultPage, $printRequest, $result );
 	}
 
 }

--- a/src/ResultFacade/SimpleQueryResult.php
+++ b/src/ResultFacade/SimpleQueryResult.php
@@ -8,12 +8,10 @@ use ParamProcessor\ProcessingResult;
 
 class SimpleQueryResult {
 
-	private $subjects;
-	private $processingResult;
-
-	public function __construct( SubjectCollection $subjects, ProcessingResult $processingResult ) {
-		$this->subjects = $subjects;
-		$this->processingResult = $processingResult;
+	public function __construct(
+		private SubjectCollection $subjects,
+		private ProcessingResult $processingResult
+	) {
 	}
 
 	public function getSubjects(): SubjectCollection {

--- a/src/ResultFacade/Subject.php
+++ b/src/ResultFacade/Subject.php
@@ -11,15 +11,16 @@ use SMW\DIWikiPage;
  */
 class Subject {
 
-	private $wikiPage;
-	private $propertyValueCollections;
+	private PropertyValueCollections $propertyValueCollections;
 
 	/**
 	 * @param DIWikiPage $wikiPage
 	 * @param PropertyValueCollection[] $propertyValueCollections
 	 */
-	public function __construct( DIWikiPage $wikiPage, array $propertyValueCollections ) {
-		$this->wikiPage = $wikiPage;
+	public function __construct(
+		private DIWikiPage $wikiPage,
+		array $propertyValueCollections
+	) {
 		$this->propertyValueCollections = new PropertyValueCollections( $propertyValueCollections );
 	}
 
@@ -27,9 +28,6 @@ class Subject {
 		return $this->wikiPage;
 	}
 
-	/**
-	 * @return PropertyValueCollection[]
-	 */
 	public function getPropertyValueCollections(): PropertyValueCollections {
 		return $this->propertyValueCollections;
 	}

--- a/src/ResultFacade/SubjectCollection.php
+++ b/src/ResultFacade/SubjectCollection.php
@@ -4,7 +4,7 @@ namespace ModernTimeline\ResultFacade;
 
 class SubjectCollection {
 
-	private $pages;
+	private array $pages;
 
 	public function __construct( Subject ...$subjects ) {
 		$this->pages = $subjects;

--- a/src/SlidePresenter/SimpleSlidePresenter.php
+++ b/src/SlidePresenter/SimpleSlidePresenter.php
@@ -7,20 +7,20 @@ namespace ModernTimeline\SlidePresenter;
 use ModernTimeline\ResultFacade\Subject;
 use SMW\DataValueFactory;
 use SMW\Query\PrintRequest;
+use Traversable;
 
 class SimpleSlidePresenter implements SlidePresenter {
 
-	private $parameters;
-
-	public function __construct( array $parameters ) {
-		$this->parameters = $parameters;
+	public function __construct(
+		private array $parameters
+	) {
 	}
 
 	public function getText( Subject $subject ): string {
 		return implode( '<br>', iterator_to_array( $this->getDisplayValues( $subject ) ) );
 	}
 
-	private function getDisplayValues( Subject $subject ) {
+	private function getDisplayValues( Subject $subject ): Traversable {
 		foreach ( $subject->getPropertyValueCollections() as $propertyValues ) {
 			foreach ( $propertyValues->getDataItems() as $dataItem ) {
 				if ( !$this->isHiddenPrintRequest( $propertyValues->getPrintRequest() ) ) {
@@ -30,11 +30,11 @@ class SimpleSlidePresenter implements SlidePresenter {
 		}
 	}
 
-	private function isHiddenPrintRequest( PrintRequest $pr ) {
+	private function isHiddenPrintRequest( PrintRequest $pr ): bool {
 		return $pr->getText( null ) === $this->parameters['image property'];
 	}
 
-	private function getDisplayValue( PrintRequest $pr, \SMWDataItem $dataItem ) {
+	private function getDisplayValue( PrintRequest $pr, \SMWDataItem $dataItem ): string {
 		$property = $pr->getText( null );
 		$value = $this->dataItemToText( $dataItem );
 

--- a/src/SlidePresenter/TemplateSlidePresenter.php
+++ b/src/SlidePresenter/TemplateSlidePresenter.php
@@ -11,10 +11,9 @@ use SMW\DataValueFactory;
 
 class TemplateSlidePresenter implements SlidePresenter {
 
-	private $templateName;
-
-	public function __construct( string $templateName ) {
-		$this->templateName = $templateName;
+	public function __construct(
+		private string $templateName
+	) {
 	}
 
 	public function getText( Subject $subject ): string {

--- a/src/TimelinePresenter.php
+++ b/src/TimelinePresenter.php
@@ -13,7 +13,7 @@ use SMWOutputs;
 
 class TimelinePresenter implements ResultPresenter {
 
-	private $id;
+	private string $id;
 
 	public function __construct() {
 		$this->id = $this->newTimelineId();
@@ -35,7 +35,7 @@ class TimelinePresenter implements ResultPresenter {
 		return $this->createDiv( $result->getParameters() );
 	}
 
-	private function createJsonString( SimpleQueryResult $result ) {
+	private function createJsonString( SimpleQueryResult $result ): string {
 		$preJson = $this->newJsonBuilder( $result )
 			->eventsToTimelineJson( ( new EventExtractor( $result->getParameters() ) )->extractEvents( $result->getSubjects() ) );
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,7 +9,8 @@ if ( PHP_SAPI !== 'cli' ) {
 error_reporting( -1 );
 ini_set( 'display_errors', '1' );
 
-if ( !is_readable( $autoloaderClassPath = __DIR__ . '/../../SemanticMediaWiki/tests/autoloader.php' ) ) {
+$autoloaderClassPath = __DIR__ . '/../../SemanticMediaWiki/tests/autoloader.php';
+if ( !is_readable( $autoloaderClassPath ) ) {
 	die( "\nThe Semantic MediaWiki test autoloader is not available" );
 }
 


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/ModernTimeline/issues/25

* Add Makefile
* Add CS
* Add CS to CI
* Fix CS
* Bump PHP/MW/SMW requirements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Enhanced continuous integration with automated quality and style checks.
  - Updated development tooling and dependency configurations.
- **Documentation**
  - Revised system requirements to now require PHP 8.0 and MediaWiki 1.39 or later.
- **Refactor**
  - Streamlined internal code for improved consistency and type safety using modern PHP features.
- **Tests**
  - Introduced new commands to simplify and strengthen testing and performance validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->