### PR TITLE
Fix issue #48 class Title and Html not found with mediawiki 1.44

### DIFF
--- a/src/JsonBuilder.php
+++ b/src/JsonBuilder.php
@@ -7,6 +7,8 @@ namespace ModernTimeline;
 use ModernTimeline\ResultFacade\SubjectCollection;
 use ModernTimeline\SlidePresenter\SlidePresenter;
 use SMWDITime;
+use MediaWiki\Title\Title;
+use MediaWiki\Html\Html;
 
 class JsonBuilder {
 
@@ -54,8 +56,8 @@ class JsonBuilder {
 		return $jsonEvent;
 	}
 
-	private function newHeadline( \Title $title ): string {
-		return \Html::element(
+	private function newHeadline( Title $title ): string {
+		return Html::element(
 			'a',
 			[ 'href' => $title->getFullURL() ],
 			$title->getText()

--- a/src/TimelinePresenter.php
+++ b/src/TimelinePresenter.php
@@ -10,6 +10,7 @@ use ModernTimeline\SlidePresenter\SimpleSlidePresenter;
 use ModernTimeline\SlidePresenter\SlidePresenter;
 use ModernTimeline\SlidePresenter\TemplateSlidePresenter;
 use SMWOutputs;
+use MediaWiki\Html\Html;
 
 class TimelinePresenter implements ResultPresenter {
 
@@ -61,7 +62,7 @@ class TimelinePresenter implements ResultPresenter {
 	}
 
 	private function createJs( string $json ): string {
-		return \Html::rawElement(
+		return Html::rawElement(
 			'script',
 			[
 				'type' => 'text/javascript'
@@ -75,14 +76,14 @@ class TimelinePresenter implements ResultPresenter {
 		$width = $parameters[TimelineOptions::PARAM_WIDTH];
 		$height = $parameters[TimelineOptions::PARAM_HEIGHT];
 
-		return \Html::rawElement(
+		return Html::rawElement(
 			'div',
 			[
 				'id' => $this->id,
 				'style' => "width: $width; height: $height",
 				'class' => 'modern_timeline_outer_div'
 			],
-			\Html::element(
+			Html::element(
 				'div',
 				[
 					'class' => 'modern_timeline_inner_div',


### PR DESCRIPTION
See Issue #48 

namespaces added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized usage of HTML rendering utilities for consistency across components.
  * Improved type consistency in internal methods for clearer intent and maintainability.
  * No changes to public APIs or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->