### PR TITLE
Drop old dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,19 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - mw: 'REL1_39'
-            php: '8.0'
-            db: 'mysql'
-            smw: '4.2.0'
-            experimental: false
-          - mw: 'REL1_41'
+          - mw: 'REL1_43'
             php: '8.1'
-            db: 'mysql'
-            # SMW 4.2.0 should be compatible with MW 1.41, but the tests are not.
-            smw: 'dev-master'
-            experimental: true
-          - mw: 'REL1_42'
-            php: '8.2'
             db: 'mysql'
             smw: 'dev-master'
             experimental: true

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Example timeline
 
 ## Platform requirements
 
-* PHP 8.0 or later
-* MediaWiki 1.39 or later (tested up to MediaWiki 1.43)
-* Semantic MediaWiki 4.0 or later (tested up to SMW 5.0.2)
+* PHP 8.1 or later
+* MediaWiki 1.43 or later (tested up to MediaWiki 1.43)
+* Semantic MediaWiki 6.0 or later (tested up to SMW 6.0.1)
 
 See the [release notes](#release-notes) for more information on the different versions of Modern Timeline.
 
@@ -40,7 +40,7 @@ create one and add the following content to it:
 ```
 {
 	"require": {
-		"professional-wiki/modern-timeline": "~2.0"
+		"professional-wiki/modern-timeline": "~3.0"
 	}
 }
 ```
@@ -48,7 +48,7 @@ create one and add the following content to it:
 If you already have a "composer.local.json" file add the following line to the end of the "require"
 section in your file:
 
-    "professional-wiki/modern-timeline": "~2.0"
+    "professional-wiki/modern-timeline": "~3.0"
 
 Remember to add a comma to the end of the preceding line in this section.
 
@@ -169,6 +169,16 @@ have a look at the contribution guideline.
 [GNU General Public License v2.0 or later (GPL-2.0-or-later)](/COPYING).
 
 ## Release notes
+
+### Version 3.0.0
+
+Under development.
+
+* Raised minimum PHP version to 8.1
+* Raised minimum MediaWiki version to 1.43
+* Raised minimum Semantic MediaWiki version to 6.0
+* Fixed compatibility with MediaWiki 1.44
+* Translation updates from https://translatewiki.net
 
 ### Version 2.0.0
 

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 		"source": "https://github.com/ProfessionalWiki/ModernTimeline"
 	},
 	"require": {
-		"php": ">=8.0",
+		"php": ">=8.1",
 		"composer/installers": "^2|^1.0.1",
 		"param-processor/param-processor": "~1.10"
 	},

--- a/extension.json
+++ b/extension.json
@@ -1,7 +1,7 @@
 {
 	"name": "ModernTimeline",
 
-	"version": "2.0.0",
+	"version": "3.0.0-dev",
 
 	"author": [
 		"[https://professional.wiki/ Professional Wiki]",
@@ -19,9 +19,9 @@
 	"type": "semantic",
 
 	"requires": {
-		"MediaWiki": ">= 1.39.0",
+		"MediaWiki": ">= 1.43.0",
 		"extensions": {
-			"SemanticMediaWiki": ">= 4.0.0"
+			"SemanticMediaWiki": ">= 6.0.0"
 		}
 	},
 


### PR DESCRIPTION
Due to MW 1.44 support in https://github.com/ProfessionalWiki/ModernTimeline/pull/49.

CI has been failing for a while, so unrelated to this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Updated README: new minimums PHP 8.1+, MediaWiki 1.43+, Semantic MediaWiki 6.0+; added Version 3.0.0 release notes and installation guidance; composer examples updated to ~3.0.
- Chores
  - Bumped extension to 3.0.0-dev and tightened dependency constraints (PHP >=8.1, MW >=1.43, SMW >=6.0).
  - Simplified CI matrix by dropping older MediaWiki entries and consolidating test targets around REL1_43 and master.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->