### PR TITLE
Run PHPUnit via composer and modernise CI for SemanticMediaWiki 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,20 +16,25 @@ jobs:
           - mw: 'REL1_43'
             php: '8.1'
             db: 'mysql'
-            smw: 'dev-master'
+            smw: '^6.0'
+            experimental: false
+          - mw: 'REL1_44'
+            php: '8.2'
+            db: 'mysql'
+            smw: '^6.0'
             experimental: true
-          - mw: 'REL1_43'
+          - mw: 'REL1_45'
             php: '8.3'
             db: 'mysql'
             smw: 'dev-master'
             experimental: true
-          - mw: 'REL1_43'
-            php: '8.3'
-            db: 'sqlite'
+          - mw: 'REL1_46'
+            php: '8.4'
+            db: 'mysql'
             smw: 'dev-master'
             experimental: true
           - mw: 'master'
-            php: '8.4'
+            php: '8.5'
             db: 'mysql'
             smw: 'dev-master'
             experimental: true
@@ -38,7 +43,7 @@ jobs:
 
     services:
       db:
-        image: mariadb
+        image: mariadb:11.8
         ports:
           - 3306:3306
         env:
@@ -94,11 +99,12 @@ jobs:
         run: php maintenance/update.php --quick
 
       - name: Run PHPUnit
-        run: php tests/phpunit/phpunit.php -c extensions/ModernTimeline/
+        working-directory: mediawiki/extensions/ModernTimeline
+        run: composer phpunit
         if: matrix.mw != 'master'
 
       - name: Run PHPUnit with code coverage
-        run: php tests/phpunit/phpunit.php -c extensions/ModernTimeline/ --coverage-clover coverage.xml
+        run: composer phpunit -- extensions/ModernTimeline/tests/ --coverage-clover coverage.xml --coverage-filter extensions/ModernTimeline/src
         if: matrix.mw == 'master'
 
       - name: Upload code coverage
@@ -116,7 +122,7 @@ jobs:
           - mw: 'REL1_43'
             php: '8.3'
             db: 'sqlite'
-            smw: 'dev-master'
+            smw: '^6.0'
 
     runs-on: ubuntu-latest
 
@@ -181,7 +187,7 @@ jobs:
           - mw: 'REL1_43'
             php: '8.3'
             db: 'sqlite'
-            smw: 'dev-master'
+            smw: '^6.0'
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/installMediaWiki.sh
+++ b/.github/workflows/installMediaWiki.sh
@@ -14,6 +14,15 @@ mv mediawiki-$MW_BRANCH mediawiki
 
 cd mediawiki
 
+# `phpunit.xml.dist` is `export-ignore`d in MediaWiki's .gitattributes, so the
+# GitHub source tarball doesn't include it — fetch it separately. MW master
+# renamed the file to `phpunit.xml.template` (read by
+# tests/phpunit/generatePHPUnitConfig.php); REL1_43 still reads `.dist`. Leave
+# wget to save under the URL's basename so the file lands under the name MW
+# core expects on that branch.
+wget -nv "https://raw.githubusercontent.com/wikimedia/mediawiki/$MW_BRANCH/phpunit.xml.dist" || \
+    wget -nv "https://raw.githubusercontent.com/wikimedia/mediawiki/$MW_BRANCH/phpunit.xml.template"
+
 composer install
 if [ "$DB" = "mysql" ]; then
     php maintenance/install.php --dbtype mysql --dbserver 127.0.0.1:3306 --dbuser mediawiki --dbpass mediawiki \
@@ -28,7 +37,6 @@ error_reporting(E_ALL| E_STRICT);
 ini_set("display_errors", "1");
 $wgShowExceptionDetails = true;
 $wgShowDBErrorBacktrace = true;
-$wgDevelopmentWarnings = true;
 EOT
 
 cat <<EOT >> LocalSettings.php

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,9 @@
 			"ModernTimeline\\Tests\\": "tests/"
 		}
 	},
+	"scripts": {
+		"phpunit": "cd ../../ && php vendor/bin/phpunit -c phpunit.xml.dist extensions/ModernTimeline/tests/"
+	},
 	"config": {
 		"allow-plugins": {
 			"composer/installers": true,

--- a/src/EventExtractor.php
+++ b/src/EventExtractor.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ModernTimeline;
 
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
 use ModernTimeline\ResultFacade\PropertyValueCollection;
 use ModernTimeline\ResultFacade\Subject;
 use ModernTimeline\ResultFacade\SubjectCollection;
@@ -51,12 +52,12 @@ class EventExtractor {
 
 	private function isImageValue( \SMWDataItem $dataItem ): bool {
 		return $dataItem instanceof DIWikiPage
-			&& $dataItem->getTitle() instanceof \Title
+			&& $dataItem->getTitle() instanceof Title
 			&& $dataItem->getTitle()->getNamespace() === NS_FILE
 			&& $dataItem->getTitle()->exists();
 	}
 
-	public function getUrlForFileTitle( \Title $existingTitle ): string {
+	public function getUrlForFileTitle( Title $existingTitle ): string {
 		return MediaWikiServices::getInstance()->getRepoGroup()->findFile( $existingTitle )->getURL();
 	}
 

--- a/src/SlidePresenter/TemplateSlidePresenter.php
+++ b/src/SlidePresenter/TemplateSlidePresenter.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ModernTimeline\SlidePresenter;
 
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Parser\Parser;
 use ModernTimeline\ResultFacade\PropertyValueCollection;
 use ModernTimeline\ResultFacade\Subject;
 use SMW\DataValueFactory;
@@ -24,7 +25,7 @@ class TemplateSlidePresenter implements SlidePresenter {
 		);
 	}
 
-	private function getParser(): \Parser {
+	private function getParser(): Parser {
 		return MediaWikiServices::getInstance()->getParser();
 	}
 

--- a/tests/System/JsonScript/0-warmup.json
+++ b/tests/System/JsonScript/0-warmup.json
@@ -1,0 +1,48 @@
+{
+	"description": "Warmup case: the first Semantic MediaWiki query in a test run returns no results (query engine cold-start), which would make whichever JSONScript case sorts first fail spuriously. This case sorts first and only asserts that the container renders, priming the engine for the assertion-bearing cases.",
+	"setup": [
+		{
+			"page": "News date",
+			"namespace": "SMW_NS_PROPERTY",
+			"contents": "[[Has type::Date]]"
+		},
+		{
+			"page": "Description",
+			"namespace": "SMW_NS_PROPERTY",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"page": "Warmup event",
+			"contents": "[[News date::August 1, 2019]] [[Description::warmup]]"
+		},
+		{
+			"page": "Warmup query",
+			"contents": "{{ #ask: [[Description::+]] | format=moderntimeline | ?News date }}"
+		}
+	],
+	"tests": [
+		{
+			"about": "the timeline container renders",
+			"type": "parser",
+			"subject": "Warmup query",
+			"assert-output": {
+				"to-contain": [
+					"modern&#95;timeline&#95;outer&#95;div"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/System/JsonScriptTest.php
+++ b/tests/System/JsonScriptTest.php
@@ -8,6 +8,7 @@ use SMW\Tests\Integration\JSONScript\JSONScriptTestCaseRunnerTest;
 
 /**
  * @group Database
+ * @coversNothing
  */
 class JsonScriptTest extends JSONScriptTestCaseRunnerTest {
 
@@ -19,7 +20,7 @@ class JsonScriptTest extends JSONScriptTestCaseRunnerTest {
 		parent::setUp();
 	}
 
-	protected function getTestCaseLocation() {
+	protected function getTestCaseLocation(): string {
 		return __DIR__ . '/JsonScript';
 	}
 

--- a/tests/Unit/EventExtractorTest.php
+++ b/tests/Unit/EventExtractorTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 use SMW\DIWikiPage;
 use SMW\Query\PrintRequest;
 use SMWDITime;
-use Title;
+use MediaWiki\Title\Title;
 
 /**
  * @covers \ModernTimeline\EventExtractor

--- a/tests/Unit/JsonBuilderTest.php
+++ b/tests/Unit/JsonBuilderTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 use SMW\DIWikiPage;
 use SMW\Query\PrintRequest;
 use SMWDITime;
-use Title;
+use MediaWiki\Title\Title;
 
 /**
  * @covers \ModernTimeline\JsonBuilder

--- a/tests/Unit/SlidePresenter/TemplateSlidePresenterTest.php
+++ b/tests/Unit/SlidePresenter/TemplateSlidePresenterTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\TestCase;
 use SMW\DIWikiPage;
 use SMW\Query\PrintRequest;
 use SMWDITime;
+use MediaWiki\Title\Title;
 
 /**
  * @covers \ModernTimeline\SlidePresenter\TemplateSlidePresenter
@@ -65,7 +66,7 @@ class TemplateSlidePresenterTest extends TestCase {
 	private function newDiWikiPage(): DIWikiPage {
 		$page = $this->createMock( DIWikiPage::class );
 
-		$page->method( 'getTitle' )->willReturn( \Title::newFromText( self::PAGE_NAME ) );
+		$page->method( 'getTitle' )->willReturn( Title::newFromText( self::PAGE_NAME ) );
 
 		return $page;
 	}


### PR DESCRIPTION
## Why

CI was red because the `dev-master` SemanticMediaWiki used across the
matrix moved to the unreleased 7.0 line, and MediaWiki deprecated (1.43)
then removed (master) the `tests/phpunit/phpunit.php` entry point.

## What

- **Run PHPUnit through `composer phpunit`** (a script in `composer.json`)
  instead of the removed entry point.
- **Fetch MediaWiki's PHPUnit config in `installMediaWiki.sh`** —
  MediaWiki `export-ignore`s `phpunit.xml.dist`/`phpunit.xml.template`
  from its Git archives, so the source tarball used in CI lacks it and
  the test bootstrap never runs without it.
- **Pin CI to the SemanticMediaWiki 6.x release line** (`^6.0`) instead of
  `dev-master`.
- **Modernise the matrix**: gate **MediaWiki 1.43**; run 1.44, 1.45, 1.46
  and master as **experimental** (see below). Pin the database image.
- **Namespace `Title`/`Parser`** (`MediaWiki\Title\Title`,
  `MediaWiki\Parser\Parser`) — the global aliases are gone in 1.44.
- **`@coversNothing`** on the JSONScript test — MediaWiki's root config
  sets `forceCoversAnnotation`, which otherwise marks it risky and fails
  the build.
- **Warmup JSONScript case** — the first SemanticMediaWiki query in a test
  run returns no results (query-engine cold-start), which made whichever
  case sorts first fail with an empty timeline. The printer renders and
  escapes correctly; a warmup case that sorts first primes the engine.

## Result

MediaWiki **1.43 gates green** (PHPUnit + PHPStan + code style).

The experimental rows are not arbitrary:

| Row | SemanticMediaWiki | Status |
|---|---|---|
| 1.43 | 6.0.1 | ✅ gating |
| 1.44 | 6.0.1 | experimental — SMW 6.0.1's *own* test harness fails on 1.44 (`atomic section canceled`), so SMW marks its 1.44 rows experimental too; it gates 1.44 only on its `master`/7.0 branch |
| 1.45 | dev-master | experimental — SemanticMediaWiki 6.0.1 does not support 1.45 (its installer fatals on `update.php`) |
| 1.46, master | dev-master | experimental — forward-compatibility canaries |

1.44 and 1.45 become gating once the extension targets SemanticMediaWiki 7.