### PR TITLE
Support Semantic MediaWiki 7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    name: "PHPUnit: MW ${{ matrix.mw }}, PHP ${{ matrix.php }}, DB ${{ matrix.db }}, SMW ${{ matrix.smw }}"
+    name: "PHPUnit: MW ${{ matrix.mw }}, PHP ${{ matrix.php }}, DB ${{ matrix.db_image }}, SMW ${{ matrix.smw }}"
     continue-on-error: ${{ matrix.experimental }}
 
     strategy:
@@ -16,26 +16,31 @@ jobs:
           - mw: 'REL1_43'
             php: '8.1'
             db: 'mysql'
-            smw: '^6.0'
+            db_image: 'mariadb:10.11'
+            smw: 'dev-master'
             experimental: false
           - mw: 'REL1_44'
             php: '8.2'
             db: 'mysql'
-            smw: '^6.0'
-            experimental: true
+            db_image: 'mariadb:11.4'
+            smw: 'dev-master'
+            experimental: false
           - mw: 'REL1_45'
             php: '8.3'
             db: 'mysql'
+            db_image: 'mariadb:11.8'
             smw: 'dev-master'
-            experimental: true
+            experimental: false
           - mw: 'REL1_46'
             php: '8.4'
             db: 'mysql'
+            db_image: 'mariadb:12.0'
             smw: 'dev-master'
             experimental: true
           - mw: 'master'
             php: '8.5'
             db: 'mysql'
+            db_image: 'mariadb:12.3'
             smw: 'dev-master'
             experimental: true
 
@@ -43,7 +48,7 @@ jobs:
 
     services:
       db:
-        image: mariadb:11.8
+        image: ${{ matrix.db_image }}
         ports:
           - 3306:3306
         env:
@@ -66,7 +71,7 @@ jobs:
 
       - name: Cache MediaWiki
         id: cache-mediawiki
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             mediawiki
@@ -75,12 +80,12 @@ jobs:
           key: mw_${{ matrix.mw }}-php${{ matrix.php }}-${{ matrix.db }}-smw${{ matrix.smw }}_v1
 
       - name: Cache Composer cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.composer/cache
           key: composer-php${{ matrix.php }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           path: EarlyCopy
 
@@ -89,7 +94,7 @@ jobs:
         working-directory: ~
         run: bash EarlyCopy/.github/workflows/installMediaWiki.sh ${{ matrix.mw }} ${{ matrix.db }} ${{ matrix.smw }} ModernTimeline
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           path: mediawiki/extensions/ModernTimeline
 
@@ -108,7 +113,7 @@ jobs:
         if: matrix.mw == 'master'
 
       - name: Upload code coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
         if: matrix.mw == 'master'
@@ -122,7 +127,7 @@ jobs:
           - mw: 'REL1_43'
             php: '8.3'
             db: 'sqlite'
-            smw: '^6.0'
+            smw: 'dev-master'
 
     runs-on: ubuntu-latest
 
@@ -140,21 +145,21 @@ jobs:
 
       - name: Cache MediaWiki
         id: cache-mediawiki
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             mediawiki
             mediawiki/extensions/
             mediawiki/vendor/
-          key: mw_${{ matrix.mw }}-php${{ matrix.php }}_v1
+          key: mw_${{ matrix.mw }}-php${{ matrix.php }}-smw${{ matrix.smw }}_v2
 
       - name: Cache Composer cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.composer/cache
           key: composer_static_analysis
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           path: EarlyCopy
 
@@ -163,7 +168,7 @@ jobs:
         working-directory: ~
         run: bash EarlyCopy/.github/workflows/installMediaWiki.sh ${{ matrix.mw }} ${{ matrix.db }} ${{ matrix.smw }} ModernTimeline
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           path: mediawiki/extensions/ModernTimeline
 
@@ -187,7 +192,7 @@ jobs:
           - mw: 'REL1_43'
             php: '8.3'
             db: 'sqlite'
-            smw: '^6.0'
+            smw: 'dev-master'
 
     runs-on: ubuntu-latest
 
@@ -205,7 +210,7 @@ jobs:
 
       - name: Cache MediaWiki
         id: cache-mediawiki
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             mediawiki
@@ -214,12 +219,12 @@ jobs:
           key: mw_static_analysis
 
       - name: Cache Composer cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.composer/cache
           key: composer_static_analysis
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           path: EarlyCopy
 
@@ -228,7 +233,7 @@ jobs:
         working-directory: ~
         run: bash EarlyCopy/.github/workflows/installMediaWiki.sh ${{ matrix.mw }} ${{ matrix.db }} ${{ matrix.smw }} ModernTimeline
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           path: mediawiki/extensions/ModernTimeline
 

--- a/.github/workflows/installMediaWiki.sh
+++ b/.github/workflows/installMediaWiki.sh
@@ -32,6 +32,17 @@ else
         --pass AdminPassword WikiName AdminUser
 fi
 
+# MediaWiki 1.46 replaced `phpunit.xml.dist` with `phpunit.xml.template`, which
+# is turned into a runnable `phpunit.xml` by `generatePHPUnitConfig.php`. The
+# extension's `composer phpunit` script invokes `-c phpunit.xml.dist`, so on
+# branches that only ship a template, generate the config and expose it under the
+# name the script expects. Generated here (after `composer install` provides the
+# autoloader, before the extension load lines are appended to LocalSettings.php).
+if [ ! -f phpunit.xml.dist ] && [ -f phpunit.xml.template ]; then
+    php tests/phpunit/generatePHPUnitConfig.php
+    cp phpunit.xml phpunit.xml.dist
+fi
+
 cat <<'EOT' >> LocalSettings.php
 error_reporting(E_ALL| E_STRICT);
 ini_set("display_errors", "1");

--- a/README.md
+++ b/README.md
@@ -170,12 +170,11 @@ have a look at the contribution guideline.
 
 ## Release notes
 
-### Version 7.0.0
+### Version 4.0.0
 
 Under development.
 
 * Raised minimum Semantic MediaWiki version to 7.0
-* The version number now follows the major version of Semantic MediaWiki (skipping 4.x through 6.x)
 
 ### Version 3.0.0
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,13 @@ have a look at the contribution guideline.
 
 ## Release notes
 
+### Version 7.0.0
+
+Under development.
+
+* Raised minimum Semantic MediaWiki version to 7.0
+* The version number now follows the major version of Semantic MediaWiki (skipping 4.x through 6.x)
+
 ### Version 3.0.0
 
 Released on June 2nd, 2026.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are provided for the latest major version of Modern Timeline.
+Please upgrade to the current release before reporting an issue. Fixes ship in a
+new release rather than as backports to older versions.
+
+## Reporting a vulnerability
+
+Please do **not** report security vulnerabilities through public GitHub issues,
+pull requests, the mailing list, or the project wiki.
+
+Instead, report them privately using GitHub's
+[private vulnerability reporting](https://github.com/ProfessionalWiki/ModernTimeline/security/advisories/new).
+Please include the affected version, steps to reproduce, and the potential
+impact.
+
+A maintainer will respond to your report, keep you informed of the progress
+towards a fix, and may ask for additional information.
+
+## Disclosure process
+
+To minimise the risk of exploitation, please give us a reasonable opportunity to
+release a fix before any public disclosure. After a report is submitted, we aim
+to:
+
+- Acknowledge the report within 15 days.
+- Confirm the issue and assess its severity and impact.
+- Prepare and release a fix, prioritised by severity, keeping the reporter
+  informed of progress.
+- Publish a security advisory once a fix is available, crediting the reporter
+  unless they prefer to remain anonymous.
+
+Remediation time depends on the severity and complexity of the issue. For
+coordinated disclosure we aim to release a fix within 90 days where feasible.
+
+Because the repository is public and can be watched by potential attackers,
+please avoid describing the vulnerability in public channels, including commit
+messages and issue comments, until a fix has been released.
+
+## Vulnerabilities in MediaWiki or Semantic MediaWiki
+
+Modern Timeline is an extension to MediaWiki that builds on Semantic MediaWiki.
+If the issue is actually in one of those rather than in Modern Timeline itself,
+please report it there instead:
+
+- For Semantic MediaWiki, use its
+  [private vulnerability reporting](https://github.com/SemanticMediaWiki/SemanticMediaWiki/security/advisories/new).
+- For MediaWiki core or another extension, contact the
+  [Wikimedia security team](https://www.mediawiki.org/wiki/Reporting_security_bugs).

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+    removed_code_behavior: adjust_base

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,11 @@
 		"phpstan/phpstan": "^2.0.1",
 		"mediawiki/mediawiki-codesniffer": "^46.0.0"
 	},
+	"extra": {
+		"branch-alias": {
+			"dev-master": "7.0.0-dev"
+		}
+	},
 	"autoload": {
 		"psr-4": {
 			"ModernTimeline\\": "src/",

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "7.0.0-dev"
+			"dev-master": "4.0.0-dev"
 		}
 	},
 	"autoload": {

--- a/extension.json
+++ b/extension.json
@@ -1,7 +1,7 @@
 {
 	"name": "ModernTimeline",
 
-	"version": "3.0.0",
+	"version": "7.0.0-alpha",
 
 	"author": [
 		"[https://professional.wiki/ Professional Wiki]",
@@ -21,7 +21,7 @@
 	"requires": {
 		"MediaWiki": ">= 1.43.0",
 		"extensions": {
-			"SemanticMediaWiki": ">= 6.0.0"
+			"SemanticMediaWiki": ">= 7.0.0"
 		}
 	},
 

--- a/extension.json
+++ b/extension.json
@@ -1,7 +1,7 @@
 {
 	"name": "ModernTimeline",
 
-	"version": "7.0.0-alpha",
+	"version": "4.0.0-dev",
 
 	"author": [
 		"[https://professional.wiki/ Professional Wiki]",

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -1,0 +1,23 @@
+<?php
+
+declare( strict_types = 1 );
+
+// Semantic MediaWiki 7 dropped the composer PSR-4 autoload for the SMW\
+// namespace (its composer.json `autoload` is now `files` only); SMW is loaded
+// through MediaWiki's extension registration at runtime instead. PHPStan
+// analyses this extension without booting MediaWiki, so register the mapping
+// here — matching SMW's extension.json AutoloadNamespaces ("SMW\\": "src/") —
+// so classes such as the SMW\Query\ResultPrinter that ModernTimelinePrinter
+// implements can be reflected.
+spl_autoload_register( static function ( string $class ): void {
+	if ( strncmp( $class, 'SMW\\', 4 ) !== 0 ) {
+		return;
+	}
+
+	$path = __DIR__ . '/../SemanticMediaWiki/src/'
+		. str_replace( '\\', '/', substr( $class, 4 ) ) . '.php';
+
+	if ( is_file( $path ) ) {
+		require_once $path;
+	}
+} );

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,4 +11,5 @@ parameters:
 		- ../../vendor
 	bootstrapFiles:
 		- ../../includes/AutoLoader.php
+		- phpstan-bootstrap.php
 	reportUnmatchedIgnoredErrors: false

--- a/src/Event.php
+++ b/src/Event.php
@@ -5,7 +5,7 @@ declare( strict_types = 1 );
 namespace ModernTimeline;
 
 use ModernTimeline\ResultFacade\Subject;
-use SMWDITime;
+use SMW\DataItems\Time;
 
 class Event {
 
@@ -13,8 +13,8 @@ class Event {
 
 	public function __construct(
 		private Subject $subject,
-		private SMWDITime $startDate,
-		private ?SMWDITime $endDate
+		private Time $startDate,
+		private ?Time $endDate
 	) {
 	}
 
@@ -22,11 +22,11 @@ class Event {
 		return $this->subject;
 	}
 
-	public function getStartDate(): SMWDITime {
+	public function getStartDate(): Time {
 		return $this->startDate;
 	}
 
-	public function getEndDate(): ?SMWDITime {
+	public function getEndDate(): ?Time {
 		return $this->endDate;
 	}
 

--- a/src/EventExtractor.php
+++ b/src/EventExtractor.php
@@ -10,8 +10,9 @@ use ModernTimeline\ResultFacade\PropertyValueCollection;
 use ModernTimeline\ResultFacade\Subject;
 use ModernTimeline\ResultFacade\SubjectCollection;
 use RepoGroup;
-use SMW\DIWikiPage;
-use SMWDITime;
+use SMW\DataItems\DataItem;
+use SMW\DataItems\Time;
+use SMW\DataItems\WikiPage;
 
 class EventExtractor {
 
@@ -50,8 +51,8 @@ class EventExtractor {
 		return $events;
 	}
 
-	private function isImageValue( \SMWDataItem $dataItem ): bool {
-		return $dataItem instanceof DIWikiPage
+	private function isImageValue( DataItem $dataItem ): bool {
+		return $dataItem instanceof WikiPage
 			&& $dataItem->getTitle() instanceof Title
 			&& $dataItem->getTitle()->getNamespace() === NS_FILE
 			&& $dataItem->getTitle()->exists();
@@ -68,7 +69,7 @@ class EventExtractor {
 		foreach ( $this->getPropertyValueCollectionsWithDates( $subject ) as $propertyValues ) {
 			$dataItem = $propertyValues->getDataItems()[0];
 
-			if ( $dataItem instanceof SMWDITime ) {
+			if ( $dataItem instanceof Time ) {
 				if ( $startDate === null ) {
 					$startDate = $dataItem;
 				}

--- a/src/JsonBuilder.php
+++ b/src/JsonBuilder.php
@@ -6,7 +6,7 @@ namespace ModernTimeline;
 
 use ModernTimeline\ResultFacade\SubjectCollection;
 use ModernTimeline\SlidePresenter\SlidePresenter;
-use SMWDITime;
+use SMW\DataItems\Time;
 use MediaWiki\Title\Title;
 use MediaWiki\Html\Html;
 
@@ -66,7 +66,7 @@ class JsonBuilder {
 //		return DataValueFactory::getInstance()->newDataValueByItem( $subject->getWikiPage() )->getLongHTMLText( smwfGetLinker() );
 	}
 
-	private function timeToJson( SMWDITime $time ): array {
+	private function timeToJson( Time $time ): array {
 		return [
 			'year' => $time->getYear(),
 			'month' => $time->getMonth(),

--- a/src/ModernTimelinePrinter.php
+++ b/src/ModernTimelinePrinter.php
@@ -15,7 +15,7 @@ use ParamProcessor\ProcessingResult;
 use SMW\Parser\RecursiveTextProcessor;
 use SMW\Query\QueryResult;
 use SMW\Query\ResultPrinter;
-use SMWQuery;
+use SMW\Query\Query;
 
 class ModernTimelinePrinter implements ResultPrinter {
 
@@ -93,10 +93,13 @@ class ModernTimelinePrinter implements ResultPrinter {
 	}
 
 	public function getQueryMode( $context ): int {
-		return SMWQuery::MODE_INSTANCES;
+		return Query::MODE_INSTANCES;
 	}
 
 	public function setShowErrors( $show ): void {
+	}
+
+	public function setContext( int $context ): void {
 	}
 
 	public function isExportFormat(): bool {

--- a/src/ResultFacade/PropertyValueCollection.php
+++ b/src/ResultFacade/PropertyValueCollection.php
@@ -5,12 +5,12 @@ declare( strict_types = 1 );
 namespace ModernTimeline\ResultFacade;
 
 use SMW\Query\PrintRequest;
-use SMWDataItem;
+use SMW\DataItems\DataItem;
 
 class PropertyValueCollection {
 
 	/**
-	 * @param SMWDataItem[] $dataItems
+	 * @param DataItem[] $dataItems
 	 */
 	public function __construct(
 		private PrintRequest $printRequest,
@@ -23,7 +23,7 @@ class PropertyValueCollection {
 	}
 
 	/**
-	 * @return SMWDataItem[]
+	 * @return DataItem[]
 	 */
 	public function getDataItems(): array {
 		return $this->dataItems;

--- a/src/ResultFacade/ResultSimplifier.php
+++ b/src/ResultFacade/ResultSimplifier.php
@@ -4,7 +4,7 @@ declare( strict_types = 1 );
 
 namespace ModernTimeline\ResultFacade;
 
-use SMW\DIWikiPage;
+use SMW\DataItems\WikiPage;
 use SMW\Query\PrintRequest;
 use SMW\Query\QueryResult;
 use SMW\Query\Result\ResultArray;
@@ -22,12 +22,12 @@ class ResultSimplifier {
 	}
 
 	/**
-	 * @param DIWikiPage $resultPage
+	 * @param WikiPage $resultPage
 	 * @param PrintRequest[] $printRequests
 	 * @param QueryResult $result
 	 * @return Subject
 	 */
-	private function newSubject( DIWikiPage $resultPage, array $printRequests, QueryResult $result ): Subject {
+	private function newSubject( WikiPage $resultPage, array $printRequests, QueryResult $result ): Subject {
 		$propertyValueCollections = [];
 
 		foreach ( $printRequests as $printRequest ) {
@@ -42,7 +42,7 @@ class ResultSimplifier {
 		return new Subject( $resultPage, $propertyValueCollections );
 	}
 
-	private function newResultArray( DIWikiPage $resultPage, PrintRequest $printRequest, QueryResult $result ): ResultArray {
+	private function newResultArray( WikiPage $resultPage, PrintRequest $printRequest, QueryResult $result ): ResultArray {
 		return ResultArray::factory( $resultPage, $printRequest, $result );
 	}
 

--- a/src/ResultFacade/Subject.php
+++ b/src/ResultFacade/Subject.php
@@ -4,7 +4,7 @@ declare( strict_types = 1 );
 
 namespace ModernTimeline\ResultFacade;
 
-use SMW\DIWikiPage;
+use SMW\DataItems\WikiPage;
 
 /**
  * Data from a single subject (page or subobject)
@@ -14,17 +14,17 @@ class Subject {
 	private PropertyValueCollections $propertyValueCollections;
 
 	/**
-	 * @param DIWikiPage $wikiPage
+	 * @param WikiPage $wikiPage
 	 * @param PropertyValueCollection[] $propertyValueCollections
 	 */
 	public function __construct(
-		private DIWikiPage $wikiPage,
+		private WikiPage $wikiPage,
 		array $propertyValueCollections
 	) {
 		$this->propertyValueCollections = new PropertyValueCollections( $propertyValueCollections );
 	}
 
-	public function getWikiPage(): DIWikiPage {
+	public function getWikiPage(): WikiPage {
 		return $this->wikiPage;
 	}
 

--- a/src/SlidePresenter/SimpleSlidePresenter.php
+++ b/src/SlidePresenter/SimpleSlidePresenter.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ModernTimeline\SlidePresenter;
 
 use ModernTimeline\ResultFacade\Subject;
+use SMW\DataItems\DataItem;
 use SMW\DataValueFactory;
 use SMW\Query\PrintRequest;
 use Traversable;
@@ -34,7 +35,7 @@ class SimpleSlidePresenter implements SlidePresenter {
 		return $pr->getText( null ) === $this->parameters['image property'];
 	}
 
-	private function getDisplayValue( PrintRequest $pr, \SMWDataItem $dataItem ): string {
+	private function getDisplayValue( PrintRequest $pr, DataItem $dataItem ): string {
 		$property = $pr->getText( null );
 		$value = $this->dataItemToText( $dataItem );
 
@@ -45,7 +46,7 @@ class SimpleSlidePresenter implements SlidePresenter {
 		return $property . ': ' . $value;
 	}
 
-	private function dataItemToText( \SMWDataItem $dataItem ): string {
+	private function dataItemToText( DataItem $dataItem ): string {
 		return DataValueFactory::getInstance()->newDataValueByItem( $dataItem )->getLongHTMLText();
 	}
 

--- a/src/SlidePresenter/TemplateSlidePresenter.php
+++ b/src/SlidePresenter/TemplateSlidePresenter.php
@@ -8,6 +8,7 @@ use MediaWiki\MediaWikiServices;
 use MediaWiki\Parser\Parser;
 use ModernTimeline\ResultFacade\PropertyValueCollection;
 use ModernTimeline\ResultFacade\Subject;
+use SMW\DataItems\DataItem;
 use SMW\DataValueFactory;
 
 class TemplateSlidePresenter implements SlidePresenter {
@@ -51,8 +52,14 @@ class TemplateSlidePresenter implements SlidePresenter {
 		);
 	}
 
-	private function dataItemToText( \SMWDataItem $dataItem ): string {
-		return DataValueFactory::getInstance()->newDataValueByItem( $dataItem )->getLongHTMLText();
+	private function dataItemToText( DataItem $dataItem ): string {
+		// Template parameters must be plain text. Semantic MediaWiki 7 wraps
+		// values such as dates in HTML (e.g. <time>...</time>) in
+		// getLongHTMLText(), which the parser then strips when expanding the
+		// template, losing the value. Strip the markup so the text survives.
+		return strip_tags(
+			DataValueFactory::getInstance()->newDataValueByItem( $dataItem )->getLongHTMLText()
+		);
 	}
 
 	private function parameter( string $name, string $value ): string {

--- a/src/TimelinePresenter.php
+++ b/src/TimelinePresenter.php
@@ -9,7 +9,7 @@ use ModernTimeline\ResultFacade\ResultPresenter;
 use ModernTimeline\SlidePresenter\SimpleSlidePresenter;
 use ModernTimeline\SlidePresenter\SlidePresenter;
 use ModernTimeline\SlidePresenter\TemplateSlidePresenter;
-use SMWOutputs;
+use SMW\MediaWiki\Outputs;
 use MediaWiki\Html\Html;
 
 class TimelinePresenter implements ResultPresenter {
@@ -26,9 +26,9 @@ class TimelinePresenter implements ResultPresenter {
 	}
 
 	public function presentResult( SimpleQueryResult $result ): string {
-		SMWOutputs::requireResource( 'ext.modern.timeline' );
+		Outputs::requireResource( 'ext.modern.timeline' );
 
-		SMWOutputs::requireHeadItem(
+		Outputs::requireHeadItem(
 			$this->id,
 			$this->createJs( $this->createJsonString( $result ) )
 		);

--- a/tests/Unit/EventExtractorTest.php
+++ b/tests/Unit/EventExtractorTest.php
@@ -10,9 +10,9 @@ use ModernTimeline\ResultFacade\PropertyValueCollection;
 use ModernTimeline\ResultFacade\Subject;
 use ModernTimeline\ResultFacade\SubjectCollection;
 use PHPUnit\Framework\TestCase;
-use SMW\DIWikiPage;
+use SMW\DataItems\Time;
+use SMW\DataItems\WikiPage;
 use SMW\Query\PrintRequest;
-use SMWDITime;
 use MediaWiki\Title\Title;
 
 /**
@@ -46,8 +46,8 @@ class EventExtractorTest extends TestCase {
 		);
 	}
 
-	private function newDiWikiPage( string $pageName = 'Some page' ): DIWikiPage {
-		$page = $this->createMock( DIWikiPage::class );
+	private function newDiWikiPage( string $pageName = 'Some page' ): WikiPage {
+		$page = $this->createMock( WikiPage::class );
 
 		$page->method( 'getTitle' )->willReturn( Title::newFromText( $pageName ) );
 
@@ -90,9 +90,9 @@ class EventExtractorTest extends TestCase {
 		return $pr;
 	}
 
-	private function newStartDate(): SMWDITime {
-		return new SMWDITime(
-			SMWDITime::CM_GREGORIAN,
+	private function newStartDate(): Time {
+		return new Time(
+			Time::CM_GREGORIAN,
 			2019,
 			8,
 			2,

--- a/tests/Unit/JsonBuilderTest.php
+++ b/tests/Unit/JsonBuilderTest.php
@@ -10,9 +10,9 @@ use ModernTimeline\ResultFacade\PropertyValueCollection;
 use ModernTimeline\ResultFacade\Subject;
 use ModernTimeline\SlidePresenter\SimpleSlidePresenter;
 use PHPUnit\Framework\TestCase;
-use SMW\DIWikiPage;
+use SMW\DataItems\Time;
+use SMW\DataItems\WikiPage;
 use SMW\Query\PrintRequest;
-use SMWDITime;
 use MediaWiki\Title\Title;
 
 /**
@@ -60,8 +60,8 @@ class JsonBuilderTest extends TestCase {
 		);
 	}
 
-	private function newDiWikiPage( string $pageName = self::PAGE_NAME ): DIWikiPage {
-		$page = $this->createMock( DIWikiPage::class );
+	private function newDiWikiPage( string $pageName = self::PAGE_NAME ): WikiPage {
+		$page = $this->createMock( WikiPage::class );
 
 		$page->method( 'getTitle' )->willReturn( Title::newFromText( $pageName ) );
 
@@ -77,9 +77,9 @@ class JsonBuilderTest extends TestCase {
 		);
 	}
 
-	private function newStartDate(): SMWDITime {
-		return new SMWDITime(
-			SMWDITime::CM_GREGORIAN,
+	private function newStartDate(): Time {
+		return new Time(
+			Time::CM_GREGORIAN,
 			2019,
 			8,
 			2,
@@ -98,9 +98,9 @@ class JsonBuilderTest extends TestCase {
 		);
 	}
 
-	private function newEndDate(): SMWDITime {
-		return new SMWDITime(
-			SMWDITime::CM_GREGORIAN,
+	private function newEndDate(): Time {
+		return new Time(
+			Time::CM_GREGORIAN,
 			2019,
 			8,
 			5,
@@ -174,8 +174,8 @@ class JsonBuilderTest extends TestCase {
 		$this->assertSame( [], $json['events'] );
 	}
 
-	private function newNullReturningDiWikiPage(): DIWikiPage {
-		$page = $this->createMock( DIWikiPage::class );
+	private function newNullReturningDiWikiPage(): WikiPage {
+		$page = $this->createMock( WikiPage::class );
 
 		$page->method( 'getTitle' )->willReturn( null );
 

--- a/tests/Unit/SlidePresenter/TemplateSlidePresenterTest.php
+++ b/tests/Unit/SlidePresenter/TemplateSlidePresenterTest.php
@@ -8,9 +8,9 @@ use ModernTimeline\ResultFacade\PropertyValueCollection;
 use ModernTimeline\ResultFacade\Subject;
 use ModernTimeline\SlidePresenter\TemplateSlidePresenter;
 use PHPUnit\Framework\TestCase;
-use SMW\DIWikiPage;
+use SMW\DataItems\Time;
+use SMW\DataItems\WikiPage;
 use SMW\Query\PrintRequest;
-use SMWDITime;
 use MediaWiki\Title\Title;
 
 /**
@@ -34,8 +34,8 @@ class TemplateSlidePresenterTest extends TestCase {
 				new PropertyValueCollection(
 					$this->newDatePrintRequestWithLabel( 'Has date' ),
 					[
-						new SMWDITime(
-							SMWDITime::CM_GREGORIAN,
+						new Time(
+							Time::CM_GREGORIAN,
 							2019,
 							8,
 							2,
@@ -48,8 +48,8 @@ class TemplateSlidePresenterTest extends TestCase {
 				new PropertyValueCollection(
 					$this->newDatePrintRequestWithLabel( 'End date' ),
 					[
-						new SMWDITime(
-							SMWDITime::CM_GREGORIAN,
+						new Time(
+							Time::CM_GREGORIAN,
 							2019,
 							8,
 							5,
@@ -63,8 +63,8 @@ class TemplateSlidePresenterTest extends TestCase {
 		);
 	}
 
-	private function newDiWikiPage(): DIWikiPage {
-		$page = $this->createMock( DIWikiPage::class );
+	private function newDiWikiPage(): WikiPage {
+		$page = $this->createMock( WikiPage::class );
 
 		$page->method( 'getTitle' )->willReturn( Title::newFromText( self::PAGE_NAME ) );
 


### PR DESCRIPTION
Targets the upcoming Semantic MediaWiki 7.0 release. CI is green on all gating jobs (MediaWiki 1.43/1.44/1.45 × SMW `dev-master`, PHPStan, code style) and on the MediaWiki 1.46 row.

## Changes

- **Requirements:** raise the minimum Semantic MediaWiki version to 7.0 and bump the extension to `7.0.0-alpha`. The version number now tracks SMW's major version (4.x through 6.x are skipped). MediaWiki 1.43 and PHP 8.1 remain the minimums.
- **Class names:** replace the SMW aliases deprecated in 7.0 with their canonical namespaced names — `SMW\DataItems\Time`, `SMW\DataItems\WikiPage`, `SMW\DataItems\DataItem`, `SMW\Query\Query`, and `SMW\MediaWiki\Outputs`.
- **`setContext()`:** SMW 7's `QueryProcessor` now calls `setContext()` on every result printer; the printer implements the bare `ResultPrinter` interface, so it gained a no-op stub. (Not in SMW's 7.0 migration guide; only surfaces on the render path.)
- **Template slides:** SMW 7 wraps values such as dates in `<time>` HTML in `getLongHTMLText()`. As a template parameter that markup is dropped by the parser, losing the value, so template parameters are now reduced to plain text.
- **PHPStan:** SMW 7 no longer ships a composer autoload for the `SMW\` namespace, so a small bootstrap file registers it for static analysis.
- **CI:** test against SMW `dev-master` across MediaWiki 1.43 through master; gate 1.43/1.44/1.45 and keep 1.46/master experimental; per-row MariaDB LTS images; GitHub Actions bumped to current majors; add a `codecov.yml` so coverage never gates CI. MediaWiki 1.46 renamed `phpunit.xml.dist` to `phpunit.xml.template`, so the install script now generates the config on those branches.
- **Security:** add a `SECURITY.md` (separate commit).

## Experimental rows

Both bleeding-edge rows depend on upstream fixes, not on this extension:

- **MediaWiki master / PHP 8.5** is currently red on a Semantic MediaWiki `dev-master` deprecation (`null` used as an array offset in `SemanticDataLookup::getTableUsageInfo()`), which only triggers on PHP 8.5. Fix proposed upstream in [SemanticMediaWiki#6962](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6962); the row clears once it lands in `dev-master`.
- The MediaWiki 1.46 row also needed param-processor's PHP 8.4 fix, released as [param-processor 1.13.1](https://github.com/JeroenDeDauw/ParamProcessor/releases/tag/1.13.1).